### PR TITLE
[watch] Add an ignore pattern for the Kate editor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,9 @@ pub fn get_ignores(debug: bool, matches: &ArgMatches) -> (bool, Vec<String>) {
     // Emacs
     opts.push("#*#".into());
     opts.push(".#*".into());
+    
+    // Kate
+    opts.push(".*.kate-swp".into());
 
     // VCS
     opts.push(format!("*{s}.hg{s}**", s = MAIN_SEPARATOR));


### PR DESCRIPTION
Kate is a text/code editor developed in the KDE project.